### PR TITLE
Add IRC message parser and tests

### DIFF
--- a/Sources/IRCKit/IRCMessage.swift
+++ b/Sources/IRCKit/IRCMessage.swift
@@ -1,0 +1,28 @@
+public struct IRCMessage: Equatable {
+    public let tags: [String: String]
+    public let prefix: IRCPrefix?
+    public let command: IRCCommand
+    public let parameters: [String]
+
+    public init(tags: [String: String] = [:], prefix: IRCPrefix? = nil, command: IRCCommand, parameters: [String] = []) {
+        self.tags = tags
+        self.prefix = prefix
+        self.command = command
+        self.parameters = parameters
+    }
+}
+
+public enum IRCPrefix: Equatable {
+    case server(String)
+    case user(nick: String, user: String?, host: String?)
+}
+
+public enum IRCCommand: Equatable {
+    case privmsg
+    case join
+    case part
+    case ping
+    case pong
+    case numeric(Int)
+    case other(String)
+}

--- a/Sources/IRCKit/IRCParser.swift
+++ b/Sources/IRCKit/IRCParser.swift
@@ -1,0 +1,108 @@
+public struct IRCParser {
+    public init() {}
+
+    public func parse(_ line: String) -> IRCMessage {
+        var rest = line[...]
+        var tags: [String: String] = [:]
+
+        // Tags
+        if rest.first == "@" {
+            if let spaceIndex = rest.firstIndex(of: " ") {
+                let tagPart = rest[rest.index(after: rest.startIndex)..<spaceIndex]
+                for pair in tagPart.split(separator: ";") {
+                    let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                    let key = String(parts[0])
+                    let value = parts.count > 1 ? String(parts[1]) : ""
+                    tags[key] = value
+                }
+                rest = rest[rest.index(after: spaceIndex)...]
+            } else {
+                let tagPart = rest.dropFirst()
+                for pair in tagPart.split(separator: ";") {
+                    let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                    let key = String(parts[0])
+                    let value = parts.count > 1 ? String(parts[1]) : ""
+                    tags[key] = value
+                }
+                rest = rest[rest.endIndex...]
+            }
+        }
+
+        // Prefix
+        var prefix: IRCPrefix? = nil
+        if rest.first == ":" {
+            if let spaceIndex = rest.firstIndex(of: " ") {
+                let prefixStr = String(rest[rest.index(after: rest.startIndex)..<spaceIndex])
+                prefix = parsePrefix(prefixStr)
+                rest = rest[rest.index(after: spaceIndex)...]
+            } else {
+                let prefixStr = String(rest.dropFirst())
+                prefix = parsePrefix(prefixStr)
+                rest = rest[rest.endIndex...]
+            }
+        }
+
+        // Command
+        let commandEnd = rest.firstIndex(of: " ") ?? rest.endIndex
+        let commandStr = String(rest[..<commandEnd])
+        let command = IRCCommand(commandStr)
+        rest = commandEnd == rest.endIndex ? rest[commandEnd...] : rest[rest.index(after: commandEnd)...]
+
+        // Parameters
+        var params: [String] = []
+        var tmp = rest
+        while !tmp.isEmpty {
+            if tmp.first == ":" {
+                params.append(String(tmp.dropFirst()))
+                break
+            }
+            if let spaceIndex = tmp.firstIndex(of: " ") {
+                params.append(String(tmp[..<spaceIndex]))
+                tmp = tmp[tmp.index(after: spaceIndex)...]
+            } else {
+                params.append(String(tmp))
+                break
+            }
+        }
+
+        return IRCMessage(tags: tags, prefix: prefix, command: command, parameters: params)
+    }
+
+    private func parsePrefix(_ str: String) -> IRCPrefix {
+        if let bang = str.firstIndex(of: "!") {
+            let nick = String(str[..<bang])
+            let remainder = str[str.index(after: bang)...]
+            if let at = remainder.firstIndex(of: "@") {
+                let user = String(remainder[..<at])
+                let host = String(remainder[remainder.index(after: at)...])
+                return .user(nick: nick, user: user.isEmpty ? nil : user, host: host.isEmpty ? nil : host)
+            } else {
+                return .user(nick: nick, user: String(remainder), host: nil)
+            }
+        } else if let at = str.firstIndex(of: "@") {
+            let nick = String(str[..<at])
+            let host = String(str[str.index(after: at)...])
+            return .user(nick: nick, user: nil, host: host.isEmpty ? nil : host)
+        } else {
+            return .server(str)
+        }
+    }
+}
+
+extension IRCCommand {
+    public init(_ raw: String) {
+        switch raw.uppercased() {
+        case "PRIVMSG": self = .privmsg
+        case "JOIN": self = .join
+        case "PART": self = .part
+        case "PING": self = .ping
+        case "PONG": self = .pong
+        default:
+            if let num = Int(raw) {
+                self = .numeric(num)
+            } else {
+                self = .other(raw)
+            }
+        }
+    }
+}

--- a/Tests/IRCKitTests/IRCParserTests.swift
+++ b/Tests/IRCKitTests/IRCParserTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import IRCKit
+
+final class IRCParserTests: XCTestCase {
+    func testPrivmsgParsing() {
+        let parser = IRCParser()
+        let message = parser.parse("@aaa=bbb;ccc :nick!user@host PRIVMSG #channel :Hello world")
+        XCTAssertEqual(message.tags["aaa"], "bbb")
+        XCTAssertEqual(message.tags["ccc"], "")
+        if case let .user(nick, user, host) = message.prefix {
+            XCTAssertEqual(nick, "nick")
+            XCTAssertEqual(user, "user")
+            XCTAssertEqual(host, "host")
+        } else {
+            XCTFail("Expected user prefix")
+        }
+        XCTAssertEqual(message.command, .privmsg)
+        XCTAssertEqual(message.parameters, ["#channel", "Hello world"])
+    }
+
+    func testNumericParsing() {
+        let parser = IRCParser()
+        let message = parser.parse(":server 001 nick :Welcome")
+        XCTAssertEqual(message.prefix, .server("server"))
+        XCTAssertEqual(message.command, .numeric(1))
+        XCTAssertEqual(message.parameters, ["nick", "Welcome"])
+    }
+
+    func testPingParsing() {
+        let parser = IRCParser()
+        let message = parser.parse("PING :server")
+        XCTAssertNil(message.prefix)
+        XCTAssertEqual(message.command, .ping)
+        XCTAssertEqual(message.parameters, ["server"])
+    }
+}

--- a/progress.md
+++ b/progress.md
@@ -2,3 +2,5 @@
 
 - Scaffolded modules: IRCKit, NetKit, DataKit, ThemeKit, macIRCApp
 - Initial package setup committed
+- Implemented IRCMessage and IRCParser with support for tags, prefixes, and basic commands
+- Added unit tests covering numerics and common IRC messages


### PR DESCRIPTION
## Summary
- implement IRCMessage and IRCParser to handle tags, prefixes and basic commands
- add tests for numeric replies and common IRC messages
- document parser progress

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b80d5a908324905321e9898a39f1