### PR TITLE
Add CAP and SASL negotiation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [],
     targets: [
         .target(name: "IRCKit"),
-        .target(name: "NetKit"),
+        .target(name: "NetKit", dependencies: ["IRCKit"]),
         .target(name: "DataKit"),
         .target(name: "ThemeKit"),
         .executableTarget(

--- a/Sources/IRCKit/IRCMessage.swift
+++ b/Sources/IRCKit/IRCMessage.swift
@@ -23,6 +23,10 @@ public enum IRCCommand: Equatable {
     case part
     case ping
     case pong
+    case cap
+    case authenticate
+    case nick
+    case user
     case numeric(Int)
     case other(String)
 }

--- a/Sources/IRCKit/IRCParser.swift
+++ b/Sources/IRCKit/IRCParser.swift
@@ -97,6 +97,10 @@ extension IRCCommand {
         case "PART": self = .part
         case "PING": self = .ping
         case "PONG": self = .pong
+        case "CAP": self = .cap
+        case "AUTHENTICATE": self = .authenticate
+        case "NICK": self = .nick
+        case "USER": self = .user
         default:
             if let num = Int(raw) {
                 self = .numeric(num)

--- a/Sources/NetKit/IRCClient.swift
+++ b/Sources/NetKit/IRCClient.swift
@@ -1,0 +1,93 @@
+import Foundation
+import IRCKit
+
+public final class IRCClient {
+    public enum SASLMechanism {
+        case plain(username: String, password: String)
+        case external
+    }
+
+    private var connection: IRCConnection
+    private let parser = IRCParser()
+    private let nick: String
+    private let username: String
+    private let sasl: SASLMechanism?
+
+    public init(connection: IRCConnection, nick: String, username: String, sasl: SASLMechanism? = nil) {
+        self.connection = connection
+        self.nick = nick
+        self.username = username
+        self.sasl = sasl
+    }
+
+    public func start() {
+        connection.lineHandler = { [weak self] line in
+            self?.handle(line: line)
+        }
+        connection.connect()
+        connection.send(line: "CAP LS 302")
+    }
+
+    private func handle(line: String) {
+        let message = parser.parse(line)
+        switch message.command {
+        case .cap:
+            handleCap(message)
+        case .authenticate:
+            handleAuthenticate(message)
+        case .numeric(let code):
+            if code == 903 { // RPL_SASLSUCCESS
+                connection.send(line: "CAP END")
+                connection.send(line: "NICK \(nick)")
+                connection.send(line: "USER \(username) 0 * :\(username)")
+            }
+        default:
+            break
+        }
+    }
+
+    private func handleCap(_ message: IRCMessage) {
+        guard message.parameters.count >= 2 else { return }
+        let sub = message.parameters[1].uppercased()
+        switch sub {
+        case "LS":
+            guard sasl != nil else {
+                connection.send(line: "CAP END")
+                connection.send(line: "NICK \(nick)")
+                connection.send(line: "USER \(username) 0 * :\(username)")
+                return
+            }
+            if message.parameters.count >= 3 {
+                let caps = message.parameters[2].split(separator: " ")
+                if caps.contains("sasl") {
+                    connection.send(line: "CAP REQ :sasl")
+                }
+            }
+        case "ACK":
+            guard sasl != nil else { return }
+            switch sasl! {
+            case .plain:
+                connection.send(line: "AUTHENTICATE PLAIN")
+            case .external:
+                connection.send(line: "AUTHENTICATE EXTERNAL")
+            }
+        default:
+            break
+        }
+    }
+
+    private func handleAuthenticate(_ message: IRCMessage) {
+        guard message.parameters.first == "+" else { return }
+        guard let sasl = sasl else { return }
+        switch sasl {
+        case .plain(let user, let password):
+            let auth = "\u{0000}\(user)\u{0000}\(password)"
+            if let data = auth.data(using: .utf8) {
+                let base64 = data.base64EncodedString()
+                connection.send(line: "AUTHENTICATE \(base64)")
+            }
+        case .external:
+            connection.send(line: "AUTHENTICATE =")
+        }
+    }
+}

--- a/Tests/NetKitTests/NetKitTests.swift
+++ b/Tests/NetKitTests/NetKitTests.swift
@@ -15,6 +15,11 @@ final class MockIRCConnection: IRCConnection {
 
     func cancel() {}
 
+    /// Convenience accessor returning all lines sent through the connection.
+    var sentLines: [String] {
+        sentData.compactMap { String(data: $0, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+
     /// Helper to feed raw data as if it was received from the network.
     func feed(_ data: Data) {
         buffer.append(data)

--- a/Tests/NetKitTests/SASLTests.swift
+++ b/Tests/NetKitTests/SASLTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import NetKit
+
+final class SASLTests: XCTestCase {
+    func testPlainSASLFlow() {
+        let mock = MockIRCConnection()
+        let client = IRCClient(connection: mock, nick: "nick", username: "user", sasl: .plain(username: "user", password: "pass"))
+        client.start()
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302"])
+        mock.feed(Data(":server CAP * LS :sasl\r\n".utf8))
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302", "CAP REQ :sasl"])
+        mock.feed(Data(":server CAP * ACK :sasl\r\n".utf8))
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302", "CAP REQ :sasl", "AUTHENTICATE PLAIN"])
+        mock.feed(Data("AUTHENTICATE +\r\n".utf8))
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302", "CAP REQ :sasl", "AUTHENTICATE PLAIN", "AUTHENTICATE AHVzZXIAcGFzcw=="])
+        mock.feed(Data(":server 903 nick :SASL authentication successful\r\n".utf8))
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302", "CAP REQ :sasl", "AUTHENTICATE PLAIN", "AUTHENTICATE AHVzZXIAcGFzcw==", "CAP END", "NICK nick", "USER user 0 * :user"])
+    }
+
+    func testExternalSASLFlow() {
+        let mock = MockIRCConnection()
+        let client = IRCClient(connection: mock, nick: "nick", username: "user", sasl: .external)
+        client.start()
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302"])
+        mock.feed(Data(":server CAP * LS :sasl\r\n".utf8))
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302", "CAP REQ :sasl"])
+        mock.feed(Data(":server CAP * ACK :sasl\r\n".utf8))
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302", "CAP REQ :sasl", "AUTHENTICATE EXTERNAL"])
+        mock.feed(Data("AUTHENTICATE +\r\n".utf8))
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302", "CAP REQ :sasl", "AUTHENTICATE EXTERNAL", "AUTHENTICATE ="])
+        mock.feed(Data(":server 903 nick :SASL authentication successful\r\n".utf8))
+        XCTAssertEqual(mock.sentLines, ["CAP LS 302", "CAP REQ :sasl", "AUTHENTICATE EXTERNAL", "AUTHENTICATE =", "CAP END", "NICK nick", "USER user 0 * :user"])
+    }
+}

--- a/progress.md
+++ b/progress.md
@@ -6,3 +6,6 @@
 - Added unit tests covering numerics and common IRC messages
 - Implemented NWConnection wrapper with TLS and CRLF framing plus mockable interface
 - Added tests validating send/receive CRLF behavior and updated networking scaffolding
+- Introduced capability negotiation with SASL PLAIN and EXTERNAL support in NetKit
+- Added integration tests using mocked server responses to verify CAP/SASL flows
+- Integration tests pass confirming successful CAP negotiation and SASL authentication


### PR DESCRIPTION
## Summary
- extend IRCKit parser/commands for CAP and AUTHENTICATE
- implement IRCClient with capability negotiation and SASL PLAIN/EXTERNAL support
- add integration tests verifying SASL handshakes and record progress

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e390db508324b0082e6ff20554e8