### PR TITLE
Add basic app store and reducers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
         .library(name: "NetKit", targets: ["NetKit"]),
         .library(name: "DataKit", targets: ["DataKit"]),
         .library(name: "ThemeKit", targets: ["ThemeKit"]),
+        .library(name: "AppStore", targets: ["AppStore"]),
         .executable(name: "macIRCApp", targets: ["macIRCApp"])
     ],
     dependencies: [],
@@ -19,6 +20,7 @@ let package = Package(
         .target(name: "NetKit", dependencies: ["IRCKit"]),
         .target(name: "DataKit"),
         .target(name: "ThemeKit"),
+        .target(name: "AppStore"),
         .executableTarget(
             name: "macIRCApp",
             dependencies: ["IRCKit", "NetKit", "DataKit", "ThemeKit"]
@@ -42,6 +44,10 @@ let package = Package(
         .testTarget(
             name: "macIRCAppTests",
             dependencies: ["macIRCApp"]
+        ),
+        .testTarget(
+            name: "AppStoreTests",
+            dependencies: ["AppStore"]
         )
     ]
 )

--- a/Sources/AppStore/AppStore.swift
+++ b/Sources/AppStore/AppStore.swift
@@ -1,0 +1,132 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+public typealias ObservableObject = Combine.ObservableObject
+public typealias Published = Combine.Published
+#else
+public protocol ObservableObject: AnyObject {}
+@propertyWrapper public struct Published<Value> {
+    public var wrappedValue: Value
+    public init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+    }
+}
+#endif
+
+public struct BufferState: Identifiable, Equatable {
+    public let id: UUID
+    public var name: String
+    public var topic: String?
+
+    public init(id: UUID = UUID(), name: String, topic: String? = nil) {
+        self.id = id
+        self.name = name
+        self.topic = topic
+    }
+}
+
+public enum BufferAction: Equatable {
+    case add(BufferState)
+    case remove(UUID)
+    case setTopic(id: UUID, topic: String?)
+}
+
+public func buffersReducer(state: inout [UUID: BufferState], action: BufferAction) {
+    switch action {
+    case .add(let buffer):
+        state[buffer.id] = buffer
+    case .remove(let id):
+        state.removeValue(forKey: id)
+    case let .setTopic(id, topic):
+        if var buffer = state[id] {
+            buffer.topic = topic
+            state[id] = buffer
+        }
+    }
+}
+
+public struct UserState: Identifiable, Equatable {
+    public let id: UUID
+    public var nick: String
+
+    public init(id: UUID = UUID(), nick: String) {
+        self.id = id
+        self.nick = nick
+    }
+}
+
+public enum UserAction: Equatable {
+    case add(UserState)
+    case remove(UUID)
+}
+
+public func usersReducer(state: inout [UUID: UserState], action: UserAction) {
+    switch action {
+    case .add(let user):
+        state[user.id] = user
+    case .remove(let id):
+        state.removeValue(forKey: id)
+    }
+}
+
+public struct TopicState: Equatable {
+    public var text: String
+    public var setBy: String?
+
+    public init(text: String, setBy: String? = nil) {
+        self.text = text
+        self.setBy = setBy
+    }
+}
+
+public enum TopicAction: Equatable {
+    case set(bufferID: UUID, TopicState)
+}
+
+public func topicsReducer(state: inout [UUID: TopicState], action: TopicAction) {
+    switch action {
+    case let .set(bufferID, topic):
+        state[bufferID] = topic
+    }
+}
+
+public struct AppState: Equatable {
+    public var buffers: [UUID: BufferState] = [:]
+    public var users: [UUID: UserState] = [:]
+    public var topics: [UUID: TopicState] = [:]
+
+    public init(buffers: [UUID: BufferState] = [:], users: [UUID: UserState] = [:], topics: [UUID: TopicState] = [:]) {
+        self.buffers = buffers
+        self.users = users
+        self.topics = topics
+    }
+}
+
+public enum AppAction: Equatable {
+    case buffer(BufferAction)
+    case user(UserAction)
+    case topic(TopicAction)
+}
+
+public func appReducer(state: inout AppState, action: AppAction) {
+    switch action {
+    case .buffer(let action):
+        buffersReducer(state: &state.buffers, action: action)
+    case .user(let action):
+        usersReducer(state: &state.users, action: action)
+    case .topic(let action):
+        topicsReducer(state: &state.topics, action: action)
+    }
+}
+
+public final class AppStore: ObservableObject {
+    @Published public private(set) var state: AppState
+
+    public init(initial state: AppState = AppState()) {
+        self.state = state
+    }
+
+    public func dispatch(_ action: AppAction) {
+        appReducer(state: &state, action: action)
+    }
+}

--- a/Tests/AppStoreTests/AppStoreTests.swift
+++ b/Tests/AppStoreTests/AppStoreTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import AppStore
+
+final class AppStoreTests: XCTestCase {
+    func testBufferReducerAddsBuffer() {
+        var state = [UUID: BufferState]()
+        let buffer = BufferState(name: "#swift")
+        buffersReducer(state: &state, action: .add(buffer))
+        XCTAssertEqual(state[buffer.id]?.name, "#swift")
+    }
+
+    func testStoreDispatchesActions() {
+        let store = AppStore()
+        let buffer = BufferState(name: "#test")
+        store.dispatch(.buffer(.add(buffer)))
+        XCTAssertEqual(store.state.buffers[buffer.id], buffer)
+    }
+}

--- a/progress.md
+++ b/progress.md
@@ -9,3 +9,4 @@
 - Introduced capability negotiation with SASL PLAIN and EXTERNAL support in NetKit
 - Added integration tests using mocked server responses to verify CAP/SASL flows
 - Integration tests pass confirming successful CAP negotiation and SASL authentication
+- Introduced reducers for buffers, users, and topics with an AppStore observable object exposing unidirectional state to the UI


### PR DESCRIPTION
## Summary
- Add AppStore module exposing app state via a simple observable object
- Implement reducers for buffers, users, and topics to support unidirectional data flow
- Document reducer hierarchy and store behavior in progress notes

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e5e64a388324bb9c6885bbd67f96